### PR TITLE
Remove unused code

### DIFF
--- a/src/main/java/com/salaboy/conferences/site/security/SecurityConfig.java
+++ b/src/main/java/com/salaboy/conferences/site/security/SecurityConfig.java
@@ -60,22 +60,6 @@ public class SecurityConfig {
                 .build();
     }
 
-    static class GrantedAuthoritiesExtractor implements Converter<Jwt, Collection<GrantedAuthority>> {
-
-        @Override
-        public Collection<GrantedAuthority> convert(Jwt jwt) {
-
-            @SuppressWarnings("unchecked")
-            var roles = (List<String>) jwt.getClaims().getOrDefault("groups", Collections.emptyList());
-
-            return roles.stream()
-                    .map(SimpleGrantedAuthority::new)
-                    .collect(Collectors.toList());
-        }
-    }
-
-
-
     @Bean
     public ReactiveOAuth2UserService<OidcUserRequest, OidcUser> oidcUserService() {
         final OidcReactiveOAuth2UserService delegate = new OidcReactiveOAuth2UserService();


### PR DESCRIPTION
Hi @salaboy,

Comparing here, I saw that class GrantedAuthoritiesExtractor is not necessary.

It is used just on microservices.